### PR TITLE
Add overlay-scrollbars

### DIFF
--- a/src/main/main.js
+++ b/src/main/main.js
@@ -13,6 +13,9 @@ app.on('ready', function () {
     mainWindow = new BrowserWindow({
         width: size.width,
         height: size.height,
+		'web-preferences': {
+			'overlay-scrollbars': true
+		},
         resizable: true
     });
 

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -13,9 +13,9 @@ app.on('ready', function () {
     mainWindow = new BrowserWindow({
         width: size.width,
         height: size.height,
-		'web-preferences': {
-			'overlay-scrollbars': true
-		},
+	'web-preferences': {
+		'overlay-scrollbars': true
+	},
         resizable: true
     });
 


### PR DESCRIPTION


Now scrollbars are hidden by default and appear only on scrolling also they have dark color what prettier that default OS X

**Before:**

![screen shot 2015-09-08 at 2 13 32 pm](https://cloud.githubusercontent.com/assets/6943514/9733823/0939bcaa-5637-11e5-98e3-23ff0f823838.png)

**After:**
![screen shot 2015-09-08 at 3 09 41 pm](https://cloud.githubusercontent.com/assets/6943514/9734436/ada49e50-563b-11e5-898d-4315da66168f.png)

**On scrolling:**

![screen shot 2015-09-08 at 2 11 25 pm](https://cloud.githubusercontent.com/assets/6943514/9733822/0935dec8-5637-11e5-982d-001cda50cd45.png)
Here drop-down list hidden behind the line becouse of strange screenshot system