### PR TITLE
Move bower to postinstall.

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,8 +63,8 @@
     "webdriverio": "3.1.0"
   },
   "scripts": {
-    "preinstall": "rm -rf node_modules; rm -rf bower_components; bower install",
-    "postinstall": "HOME=~/.electron-gyp cd node_modules/pty.js; node-gyp rebuild --target=0.30.0 --arch=ia64 --dist-url=https://atom.io/download/atom-shell",
+    "preinstall": "npm prune",
+    "postinstall": "HOME=~/.electron-gyp bower prune; bower install; cd node_modules/pty.js; node-gyp rebuild --target=0.30.0 --arch=ia64 --dist-url=https://atom.io/download/atom-shell",
     "start": "gulp",
     "package": "electron-packager . 'Black Screen' --overwrite --platform=darwin --arch=x64 --version='0.30.0' --out='/Applications' --icon='./icon.icns'",
     "test": "gulp typescript; gulp compile-tests; electron run-tests.js"


### PR DESCRIPTION
* Don't use `rm` because it doesn't work on Windows.
* Move the `bower` commands to the `postinstall` hook since it might not be installed yet.