### PR TITLE
Include prerequisites in README install instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,19 @@ As opposed to most of the terminal emulators, it exploits the capabilities of co
 
 Note: Only OS X is currently supported, but we plan to make Black Screen work on all the major platforms.
 
+###### Prerequisites
+You'll need a working node installation, and bower installed globally.
+Use [homebrew](http://brew.sh/) to install node.
+```bash
+brew install node
+npm install -g bower
+```
+
+(Optional) Disable bower prompt during installs.
+```bash
+echo '{"analytics": false}' > ~/.bowerrc
+```
+
 ###### Download
 ```bash
 git clone https://github.com/black-screen/black-screen

--- a/README.md
+++ b/README.md
@@ -21,7 +21,17 @@ Note: Only OS X is currently supported, but we plan to make Black Screen work on
 
 ###### Prerequisites
 You'll need a working node installation, and bower installed globally.
-Use [homebrew](http://brew.sh/) to install node.
+We'll use [homebrew](http://brew.sh/) to install node.
+
+If the following commands both display paths to these executables,
+you can skip this section:
+
+```bash
+which npm
+which bower
+```
+
+Otherwise you'll need to complete the following steps:
 ```bash
 brew install node
 npm install -g bower


### PR DESCRIPTION
This is a small change to README.md that makes mention of how to install node and use npm to install bower globally. These are required to complete the first `npm install` step of the installation instructions.

Since on most machines this will already be done, and is not specific to black-screen, I created a `prerequistes` section in the README so most people can just skip over it.