### PR TITLE
Fixing createWindow from main.js

### DIFF
--- a/src/main/main.js
+++ b/src/main/main.js
@@ -32,7 +32,7 @@ function createWindow() {
 	});
 	
 	window.loadUrl('file://' + __dirname + '/../../index.html');
-	menu.setMenu(app, mainWindow);
+	menu.setMenu(app, window);
 	
 	window.on('closed', function() {
 		window = null;


### PR DESCRIPTION
Hello, I was getting the following exception when running `npm start`

```
Uncaught Exception:
TypeError: Cannot read property 'setMenu' of undefined
    at Object.module.exports.setMenu (/home/erick/projects/black-screen/src/main/menu.js:210:23)
    at createWindow (/home/erick/projects/black-screen/src/main/main.js:35:7)
    at EventEmitter.<anonymous> (/home/erick/projects/black-screen/src/main/main.js:10:15)
    at emitOne (events.js:82:20)
    at EventEmitter.emit (events.js:169:7)
```

I think the wrong variable is been passed to the `menu.setMenu`