### PR TITLE
Updates package script to run gulp build before electron-packager

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -100,12 +100,14 @@ gulp.task("clean", () => {
     require("del").sync([options.typeScript.target + "/**"]);
 });
 
+gulp.task("build", ["typescript", "sass", "react"]);
+
 gulp.task("watch", cb => {
     watching = true;
     $.livereload.listen();
     runSequence(
         "clean",
-        ["typescript", "sass", "react"],
+        "build",
         () => {
             gulp.watch(options.sass.source, ["sass"]);
             gulp.watch(options.react.source, ["react"]);

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "preinstall": "npm prune",
     "postinstall": "bower prune; bower install; electron-rebuild",
     "start": "gulp",
-    "package": "electron-packager . 'Black Screen' --overwrite --platform=darwin --arch=x64 --version='0.33.0' --out='/Applications' --icon='./icon.icns'",
+    "package": "gulp build && electron-packager . 'Black Screen' --overwrite --platform=darwin --arch=x64 --version='0.33.0' --out='/Applications' --icon='./icon.icns'",
     "test": "gulp typescript; gulp compile-tests; electron run-tests.js"
   },
   "license": "MIT"


### PR DESCRIPTION
Proposing a solution for #32. 

It seems like the tasks for compiling `typescript`, `react` and `sass` isn't run before `npm run package`, which is what's causing this issue, if you haven't run `npm start` yet.

This is a possible scenario that works.

@luizkowalski @jbaskeen @mzgnr 