### PR TITLE
Adjust build scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "black-screen",
+  "productName": "Black Screen",
   "version": "0.0.1",
   "description": "A terminal emulator for the 21st century.",
   "main": "src/main/main.js",
@@ -21,6 +22,7 @@
     "shell",
     "console"
   ],
+  "electronVersion": "0.33.3",
   "dependencies": {
     "font-awesome": "4.4.0",
     "fuzzaldrin": "2.1.0",
@@ -29,7 +31,7 @@
     "lodash": "3.10.1",
     "node-ansiparser": "2.0.2",
     "octicons": "2.4.1",
-    "ptyw.js": "^0.3.2",
+    "ptyw.js": "0.3.2",
     "react": "0.13.3",
     "react-json-inspector": "5.2.1",
     "rx": "3.1.2"
@@ -66,9 +68,9 @@
   "scripts": {
     "preinstall": "npm prune",
     "postinstall": "bower prune; bower install; npm run recompile",
-    "recompile": "HOME=~/.electron-gyp cd node_modules/ptyw.js; node-gyp rebuild --target=0.33.3 --arch=ia64 --dist-url=https://atom.io/download/atom-shell",
+    "recompile": "HOME=~/.electron-gyp cd node_modules/ptyw.js; node-gyp rebuild --target=$npm_package_electronVersion --arch=x64 --dist-url=https://atom.io/download/atom-shell",
     "start": "gulp",
-    "package": "gulp build && electron-packager . 'Black Screen' --overwrite --platform=darwin --arch=x64 --version='0.33.3' --out='/Applications' --icon='./icon.icns'",
+    "package": "gulp build && electron-packager . $npm_package_productName --overwrite --platform=darwin --arch=x64 --version=$npm_package_electronVersion --out='/Applications' --icon='./icon.icns'",
     "test": "gulp typescript; gulp compile-tests; electron run-tests.js"
   },
   "license": "MIT"


### PR DESCRIPTION
### Notes
- Arch *ia64* doesn't exist, it's x64.
- Set an exact version for the module **ptyw.js**.
- Create "productName" & "electronVersion" parameters and use them in the different scripts.

In addition, I think it's time to bump the package version to something like 0.0.3-alpha (this last has not been added to the PR yet).