### PR TITLE
Updated Electron to 0.35.0 and fixed deprecation warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "shell",
     "console"
   ],
-  "electronVersion": "0.34.3",
+  "electronVersion": "0.35.0",
   "dependencies": {
     "fixed-sticky": "^0.1.6",
     "font-awesome": "4.4.0",
@@ -50,7 +50,7 @@
     "chai-things": "0.2.0",
     "del": "2.0.2",
     "electron-packager": "5.1.1",
-    "electron-prebuilt": "0.34.3",
+    "electron-prebuilt": "0.35.0",
     "electron-rebuild": "1.0.2",
     "gulp": "3.9.0",
     "gulp-babel": "6.1.0",

--- a/src/main/Main.ts
+++ b/src/main/Main.ts
@@ -1,6 +1,6 @@
 const app = require('app');
 const BrowserWindow = require('browser-window');
-const IPC = require('ipc');
+const IPC = require('electron').ipcMain;
 let menu = require('./Menu');
 
 let browserWindow: any = null;
@@ -31,7 +31,7 @@ function getMainWindow() {
             show: false
         });
 
-        browserWindow.loadUrl('file://' + __dirname + '/../views/index.html');
+        browserWindow.loadURL('file://' + __dirname + '/../views/index.html');
         menu.setMenu(app, browserWindow);
 
         browserWindow.on('closed', (): void => browserWindow = null);


### PR DESCRIPTION
- `loadUrl` has become `loadURL`
- `ipc` module has been renamed to `ipcMain`

Full changelog: https://github.com/atom/electron/releases/tag/v0.35.0
